### PR TITLE
teensy refactor to line array methods

### DIFF
--- a/lib/braille_converter.rb
+++ b/lib/braille_converter.rb
@@ -58,7 +58,7 @@ class BrailleConverter
 
   def putting_elements_in_row_1(converted)
     line_1 = []
-    converted.map do |char_1|
+    converted.each do |char_1|
       line_1 << char_1[0]
     end
     @output << line_1
@@ -66,7 +66,7 @@ class BrailleConverter
 
   def putting_elements_in_row_2(converted)
     line_2 = []
-    converted.map do |char_2|
+    converted.each do |char_2|
       # require "pry"; binding.pry
       line_2 << char_2[1]
     end
@@ -75,7 +75,7 @@ class BrailleConverter
 
   def putting_elements_in_row_3(converted)
     line_3 = []
-    converted.map do |char_3|
+    converted.each do |char_3|
       line_3 << char_3[2]
     end
     @output << line_3

--- a/lib/braille_converter.rb
+++ b/lib/braille_converter.rb
@@ -6,31 +6,33 @@ class BrailleConverter
     @conversion_map = {
       "a" => ["0.", "..", ".."],
       "b" => ["0.", "0.", ".."],
-      "c" => ["00...."],
-      "d" => ["00.0.."],
-      "e" => ["0..0.."],
-      "f" => ["000..."],
-      "g" => ["0000.."],
-      "h" => ["0.00.."],
-      "i" => [".00..."],
-      "j" => [".000.."],
-      "k" => ["0...0."],
-      "l" => ["0.0.0."],
-      "m" => ["00..0."],
-      "n" => ["00.00."],
-      "o" => ["0..00."],
-      "p" => ["000.0."],
-      "q" => ["00000."],
-      "r" => ["0.000."],
-      "s" => [".00.0."],
-      "t" => [".0000."],
-      "u" => ["0...00"],
-      "v" => ["0.0.00"],
-      "w" => [".000.0"],
-      "x" => ["00..00"],
-      "y" => ["00.000"],
-      "z" => ["0..000"]
+      "c" => ["00", "..", ".."],
+      "d" => ["00", ".0", ".."],
+      "e" => ["0.", ".0", ".."],
+      "f" => ["00", "0.", ".."],
+      "g" => ["00", "00", ".."],
+      "h" => ["0.", "00", ".."],
+      "i" => [".0", "0.", ".."],
+      "j" => [".0", "00", ".."],
+      "k" => ["0.", "..", "0."],
+      "l" => ["0.", "0.", "0."],
+      "m" => ["00", "..", "0."],
+      "n" => ["00", ".0", "0."],
+      "o" => ["0.", ".0", "0."],
+      "p" => ["00", "0.", "0."],
+      "q" => ["00", "00", "0."],
+      "r" => ["0.", "00", "0."],
+      "s" => [".0", "0.", "0."],
+      "t" => [".0", "00", "0."],
+      "u" => ["0.", "..", "00"],
+      "v" => ["0.", "0.", "00"],
+      "w" => [".0", "00", ".0"],
+      "x" => ["00", "..", "00"],
+      "y" => ["00", ".0", "00"],
+      "z" => ["0.", ".0", "00"],
+      " " => ["..", "..", ".."]
     }
+
     @output = []
   end
 
@@ -42,42 +44,40 @@ class BrailleConverter
   end
 
   def convert_plain_text_to_braille(incoming_text)
-    conversion = convert(incoming_text)
-    putting_elements_in_row_1(conversion)
-    putting_elements_in_row_2(conversion)
-    putting_elements_in_row_3(conversion)
+    converted = convert(incoming_text)
+    putting_elements_in_row_1(converted)
+    putting_elements_in_row_2(converted)
+    putting_elements_in_row_3(converted)
   end
 
   def convert(input)
-    conversion = input.chars.map do |letter|
+    converted = input.chars.map do |letter|
       @conversion_map[letter]
     end
   end
 
-  def putting_elements_in_row_1(conversion)
+  def putting_elements_in_row_1(converted)
     line_1 = []
     converted.map do |char_1|
-      line_1 << converted[0][0]
+      line_1 << char_1[0]
     end
     @output << line_1
   end
 
-  def putting_elements_in_row_2(conversion)
+  def putting_elements_in_row_2(converted)
     line_2 = []
     converted.map do |char_2|
-      line_2 << converted[0][1]
+      # require "pry"; binding.pry
+      line_2 << char_2[1]
     end
     @output << line_2
   end
 
-  def putting_elements_in_row_3(conversion)
+  def putting_elements_in_row_3(converted)
     line_3 = []
     converted.map do |char_3|
-      line_3 << converted[0][1]
+      line_3 << char_3[2]
     end
     @output << line_3
   end
 end
-
-# bc = BrailleConverter.new
-# bc.convert_plain_text_to_braille("a")

--- a/lib/braille_converter.rb
+++ b/lib/braille_converter.rb
@@ -39,7 +39,7 @@ class BrailleConverter
   def output_to_file(incoming_text)
     convert_plain_text_to_braille(incoming_text)
     @output.map do |element|
-     element << "\n"
+     eelement.join.scan(/.{80}/) << "\n"
    end.join
   end
 

--- a/lib/night_writer.rb
+++ b/lib/night_writer.rb
@@ -26,15 +26,27 @@
 # end
 
 require_relative "./braille_converter"
+
 reader = File.open(ARGV[0], "r")
 incoming_text = reader.read
 reader.close
 
 braille_converter = BrailleConverter.new
-outgoing_text = braille_converter.output_to_file(incoming_text.strip)
+outgoing_text = nw.output(incoming_text.strip)
+require "pry"; binding.pry
 writer = File.open(ARGV[1], "w")
-writer.write(outgoing_text)
+outgoing_text[0].each_index do |i|
+  writer.write(outgoing_text[0][i] <<"\n")
+  writer.write(outgoing_text[1][i] <<"\n")
+  writer.write(outgoing_text[2][i] <<"\n")
+end
+# writer.write(outgoing_text)
 writer.close
+
+# outgoing_text = braille_converter.output_to_file(incoming_text.strip)
+# writer = File.open(ARGV[1], "w")
+# writer.write(outgoing_text)
+# writer.close
 
 character_number = (outgoing_text.length)
 puts "Created '#{ARGV[1]}' containing #{character_number} characters."

--- a/lib/night_writer.rb
+++ b/lib/night_writer.rb
@@ -29,13 +29,12 @@ require_relative "./braille_converter"
 reader = File.open(ARGV[0], "r")
 incoming_text = reader.read
 reader.close
-# puts incoming_text
 
 braille_converter = BrailleConverter.new
-outgoing_text = braille_converter.convert_plain_text_to_braille(incoming_text.strip)
+outgoing_text = braille_converter.output_to_file(incoming_text.strip)
 writer = File.open(ARGV[1], "w")
 writer.write(outgoing_text)
 writer.close
-# puts outgoing_text
-character_number = (outgoing_text.length) -1
+
+character_number = (outgoing_text.length)
 puts "Created '#{ARGV[1]}' containing #{character_number} characters."

--- a/message.txt
+++ b/message.txt
@@ -1,1 +1,1 @@
-a 
+hello world

--- a/test/braille_converter_test.rb
+++ b/test/braille_converter_test.rb
@@ -4,6 +4,7 @@ require "pry"
 require "./lib/braille_converter"
 
 class BrailleConverterTest < Minitest::Test
+
   def test_it_exists
     braille_converter = BrailleConverter.new
     assert_instance_of BrailleConverter, braille_converter
@@ -12,89 +13,146 @@ class BrailleConverterTest < Minitest::Test
 
   def test_it_converts_input_to_braille
     braille_converter = BrailleConverter.new
-    actual = braille_converter.convert("a")
+
     expected = [["0.", "..", ".."]]
-    assert_equal expected, actual
+    assert_equal expected, braille_converter.convert("a")
+
+    expected = [["0.", ".0", "00"]]
+    assert_equal expected, braille_converter.convert("z")
   end
 
-  def test_it_puts_elements_in_line_1
+  def test_it_moves_first_element_of_single_braille_letter_in_line_1
     braille_converter = BrailleConverter.new
 
-    expected = ["0."]
-    assert_equal expected, braille_converter.putting_elements_in_row_1([["0.", "..", ".."]])
-  end
+    converted = braille_converter.convert("a")
 
-  def test_it_puts_elements_in_row_2
-    braille_converter = BrailleConverter.new
-    # braille_converter.convert("a")
-    expected = [".."]
-    assert_equal expected, braille_converter.putting_elements_in_row_2([["0.", "..", ".."]])
-  end
-
-  def test_it_puts_elements_in_row_3
-    braille_converter = BrailleConverter.new
-    # braille_converter.convert("a")
-    expected = [".."]
-    assert_equal expected, braille_converter.putting_elements_in_row_3([["0.", "..", ".."]])
-  end
-
-$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
-  def test_it_can_move_first_two_characters_of_multiple_letters_to_a_new_array
-    skip
-    nw = NightWriterPlayground.new
-
-    input = [["0.", "..", ".."], ["0.", "0.", ".."]]
-    actual = nw.move_braille_letter_element_to_new_array(input)
-    expected = ['0.', '0.']
+    expected = [["0."]]
+    actual = braille_converter.putting_elements_in_row_1(converted)
 
     assert_equal expected, actual
   end
 
-  def test_it_can_move_second_set_of_braille_characters_of_multiple_letters_to_an_array
-    skip
-    nw = NightWriterPlayground.new
+  def test_it_moves_first_elements_of_a_different_letter_in_line_1
+    # skip
+    braille_converter = BrailleConverter.new
 
-    input = [["0.", "..", ".."]]
-    actual = nw.move_second_braille_letter_element_to_new_array(input)
-    expected = ['..']
+    converted = braille_converter.convert("z")
+
+    expected = [["0."]]
+    actual = braille_converter.putting_elements_in_row_1(converted)
+    assert_equal expected, actual
+  end
+
+  def test_it_moves_first_element_of_single_braille_letter_in_line_2
+    braille_converter = BrailleConverter.new
+
+    converted = braille_converter.convert("a")
+
+    expected = [[".."]]
+    actual = braille_converter.putting_elements_in_row_2(converted)
 
     assert_equal expected, actual
   end
 
-  def test_it_can_translate_two_letters_to_a_braille_letter
-    skip
-    nw = NightWriterPlayground.new
+  def test_it_moves_first_elements_of_a_different_letter_in_line_2
+    # skip
+    braille_converter = BrailleConverter.new
 
-    actual = nw.convert_plain_text_letter_to_braille_letter("ab")
+    converted = braille_converter.convert("z")
+
+    expected = [[".0"]]
+    actual = braille_converter.putting_elements_in_row_2(converted)
+
+    assert_equal expected, actual
+  end
+
+  def test_it_moves_first_element_of_single_braille_letter_in_line_3
+    braille_converter = BrailleConverter.new
+
+    converted = braille_converter.convert("a")
+
+    expected = [[".."]]
+    actual = braille_converter.putting_elements_in_row_3(converted)
+
+    assert_equal expected, actual
+  end
+
+  def test_it_moves_first_elements_of_a_different_letter_in_line_3
+    braille_converter = BrailleConverter.new
+
+    converted = braille_converter.convert("z")
+
+    expected = [["00"]]
+    actual = braille_converter.putting_elements_in_row_3(converted)
+
+    assert_equal expected, actual
+  end
+# ----------------BEGIN MULTIPLE LETTER TESTS-----------------------------
+  def test_it_can_translate_two_letters_to_braille
+    # skip
+    braille_converter = BrailleConverter.new
+
     expected = [["0.", "..", ".."], ["0.", "0.", ".."]]
 
+    assert_equal expected, braille_converter.convert("ab")
+  end
+
+  def test_it_can_put_first_elements_of_multiple_braille_letters_in_new_array
+    # skip
+    braille_converter = BrailleConverter.new
+
+    converted = braille_converter.convert("ab")
+
+    expected = [['0.', '0.']]
+    actual = braille_converter.putting_elements_in_row_1(converted)
+
     assert_equal expected, actual
   end
-$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
 
-
-#######################
-
-  def test_it_puts_two_elements_in_row_1
+  def test_it_can_put_second_elements_of_multiple_braille_letters_in_new_array
+    # skip
     braille_converter = BrailleConverter.new
-    # braille_converter.convert("a")
-    expected = ["0.", "0."]
-    input = [["0.", "..", ".."],["0.", "0.", ".."]]
-    assert_equal expected, braille_converter.putting_elements_in_row_1(input)
+
+    converted = braille_converter.convert("ab")
+
+    expected = [['..', '0.']]
+    actual = braille_converter.putting_elements_in_row_2(converted)
+
+    assert_equal expected, actual
   end
 
+  def test_it_can_put_third_elements_of_multiple_braille_letters_in_new_array
+    # skip
+    braille_converter = BrailleConverter.new
 
+    converted = braille_converter.convert("ab")
 
-###############################
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    expected = [["..", ".."]]
+    actual = braille_converter.putting_elements_in_row_3(converted)
 
-  def test_runner
-  skip
-    nw = NightWriterPlayground.new
+    assert_equal expected, actual
+  end
+# ------------------END MULTIPLE LETTER TESTS--------------------------------
+
+# ------------------BEGIN INTEGRATION TESTS----------------------------------
+  def test_it_converts_a_plain_text_letter_to_braille
+  # skip
+    braille_converter = BrailleConverter.new
 
     expected = [['0.'], ['..'], ['..']]
+    actual = braille_converter.convert_plain_text_to_braille("a")
 
-    assert_equal expected, nw.runner("a")
+    assert_equal expected, actual
   end
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  def test_it_can_convert_multiple_plain_text_letters_to_braille
+  # skip
+    braille_converter = BrailleConverter.new
+
+    expected = [["0.", "0.", "0.", "0.", "0."], ["00", ".0", "0.", "0.", ".0"], ["..", "..", "0.", "0.", "0."]]
+    actual = braille_converter.convert_plain_text_to_braille("hello")
+
+    assert_equal expected, actual
+  end
+  # ------------------END INTEGRATION TESTS-----------------------------------
 end


### PR DESCRIPTION
tiny refactor on the line 1, 2, 3 array methods to switch out the map enums for each since the return value is already being captured in each line array